### PR TITLE
strlen() with null param issue

### DIFF
--- a/src/Ratchet/Server/IoServer.php
+++ b/src/Ratchet/Server/IoServer.php
@@ -85,7 +85,7 @@ class IoServer {
 
         $uri = $conn->getRemoteAddress();
         $conn->decor->remoteAddress = trim(
-            parse_url((strpos($uri, '://') === false ? 'tcp://' : '') . $uri, PHP_URL_HOST),
+            parse_url((strpos(($uri ?? ''), '://') === false ? 'tcp://' : '') . $uri, PHP_URL_HOST),
             '[]'
         );
 


### PR DESCRIPTION
strlen(): Passing null to parameter #1 when using PHP >= 8.1